### PR TITLE
feat(auth) : create two endpoints

### DIFF
--- a/Doyep.Analyzer.Api/Doyep.Analyzer.Api.csproj
+++ b/Doyep.Analyzer.Api/Doyep.Analyzer.Api.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Doyep.Analyzer.Api/Doyep.Analyzer.Api.http
+++ b/Doyep.Analyzer.Api/Doyep.Analyzer.Api.http
@@ -1,6 +1,0 @@
-@Doyep.Analyzer.Api_HostAddress = http://localhost:5176
-
-GET {{Doyep.Analyzer.Api_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/Doyep.Analyzer.Api/Features/ApiEndpoints.cs
+++ b/Doyep.Analyzer.Api/Features/ApiEndpoints.cs
@@ -1,0 +1,19 @@
+using Scalar.AspNetCore;
+
+namespace Doyep.Analyzer.Api;
+
+/// <summary>
+/// This class contains extension methods for mapping API endpoints to the application.
+/// </summary>
+public static class ApiEndpoints
+{
+    public static IEndpointRouteBuilder MapApiEndpoints(this IEndpointRouteBuilder app)
+    {
+        var apiGroup = app.MapGroup("/api");
+
+        apiGroup.MapGet("/health", Health.Handle)
+            .ExcludeFromApiReference();
+
+        return app;
+    }
+}

--- a/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
@@ -1,0 +1,24 @@
+namespace Doyep.Analyzer.Api;
+
+/// <summary>
+/// This class contains extensions methods for mapping Authentication endpoints to the application.
+/// </summary>
+public static class AuthEndpoints
+{
+    public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        var authGroup = app.MapGroup("/auth")
+            .WithTags("Auth");
+
+        authGroup.MapGet("/login", Login.Handle)
+            .WithDescription("Redirects the user to the Strava login page.\n\nRedirections doesnt work in Scalar, you can't test this endpoint in this environment.")
+            .Produces(StatusCodes.Status302Found);
+
+        authGroup.MapGet("/callback", ExchangeToken.Handle)
+            .WithDescription("Callback endpoint for handling the Strava token exchanges. Exchanges the authorization code for an access token and a refresh token. While work in progress, it returns an bad request response if the authenticated user is not present in the whitelist, otherwise it return the access token.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
+
+        return app;
+    }
+}

--- a/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
@@ -14,7 +14,7 @@ public static class AuthEndpoints
             .WithDescription("Redirects the user to the Strava login page.\n\nRedirections doesnt work in Scalar, you can't test this endpoint in this environment.")
             .Produces(StatusCodes.Status302Found);
 
-        authGroup.MapGet("/callback", ExchangeToken.Handle)
+        authGroup.MapGet("/callback", Callback.Handle)
             .WithDescription("Callback endpoint for handling the Strava token exchanges. Exchanges the authorization code for an access token and a refresh token. While work in progress, it returns an bad request response if the authenticated user is not present in the whitelist, otherwise it return the access token.")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);

--- a/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/AuthEndpoints.cs
@@ -17,6 +17,7 @@ public static class AuthEndpoints
         authGroup.MapGet("/callback", Callback.Handle)
             .WithDescription("Callback endpoint for handling the Strava token exchanges. Exchanges the authorization code for an access token and a refresh token. While work in progress, it returns an bad request response if the authenticated user is not present in the whitelist, otherwise it return the access token.")
             .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status302Found)
             .Produces(StatusCodes.Status400BadRequest);
 
         return app;

--- a/Doyep.Analyzer.Api/Features/Auth/Callback.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/Callback.cs
@@ -9,7 +9,7 @@ namespace Doyep.Analyzer.Api;
 /// If the authenticated <see cref="Athlete"> is not present in the Whitelist, it return an unauthorized response.
 /// If all checks pass, it return the access token.
 /// </summary>
-public static class ExchangeToken
+public static class Callback
 {
     public static async Task<IResult> Handle(string code, string scope, IStravaAuthenticationService strava)
     {

--- a/Doyep.Analyzer.Api/Features/Auth/Callback.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/Callback.cs
@@ -3,11 +3,14 @@ using Doyep.Analyzer.Application.Strava;
 
 namespace Doyep.Analyzer.Api;
 
-/// <summary>
-/// This class contains the endpoint for handling Strava token exchange callback.
-/// If the scope doesn't include all read permissions, it return an bad request response.
-/// If the authenticated <see cref="Athlete"> is not present in the Whitelist, it return an unauthorized response.
-/// If all checks pass, it return the access token.
+/// /// <summary>
+/// Handles the Strava OAuth token exchange callback.
+/// If the user cancelled the authentication process, it returns a redirection to the login page.
+/// If the provided scope does not include all required read permissions, a bad request response is returned.
+/// If the authenticated <see cref="Athlete"/> is not present in the whitelist, an unauthorized response is returned.
+/// If all checks pass, the access token is returned.
+/// 
+/// TODO : Still work in progress.
 /// </summary>
 public static class Callback
 {

--- a/Doyep.Analyzer.Api/Features/Auth/ExchangeToken.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/ExchangeToken.cs
@@ -1,0 +1,20 @@
+using Doyep.Analyzer.Application.Auth;
+using Doyep.Analyzer.Application.Strava;
+
+namespace Doyep.Analyzer.Api;
+
+/// <summary>
+/// This class contains the endpoint for handling Strava token exchange callback.
+/// If the scope doesn't include all read permissions, it return an bad request response.
+/// If the authenticated <see cref="Athlete"> is not present in the Whitelist, it return an unauthorized response.
+/// If all checks pass, it return the access token.
+/// </summary>
+public static class ExchangeToken
+{
+    public static async Task<IResult> Handle(string code, string scope, IStravaAuthenticationService strava)
+    {
+        if (!ScopeValidator.HasRequiredScope(scope)) return Results.BadRequest("Missing required scope. Please ensure you have granted all necessary permissions.");
+        var token = await strava.ExchangeToken(code);
+        return token is not null ? Results.Ok(token) : Results.Unauthorized();
+    }
+}

--- a/Doyep.Analyzer.Api/Features/Auth/Login.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/Login.cs
@@ -1,0 +1,15 @@
+using Doyep.Analyzer.Application.Strava;
+
+namespace Doyep.Analyzer.Api;
+
+/// <summary>
+/// This class contains the endpoint for handling user login.
+/// The login workflow isn't handled by the API, this endpoint provides a redirection to the Strava login page.
+/// </summary>
+public static class Login
+{
+    public static IResult Handle(IStravaAuthenticationService strava)
+    {
+        return Results.Redirect(strava.GenerateLoginUrl());
+    }
+}

--- a/Doyep.Analyzer.Api/Features/Auth/Login.cs
+++ b/Doyep.Analyzer.Api/Features/Auth/Login.cs
@@ -3,8 +3,7 @@ using Doyep.Analyzer.Application.Strava;
 namespace Doyep.Analyzer.Api;
 
 /// <summary>
-/// This class contains the endpoint for handling user login.
-/// The login workflow isn't handled by the API, this endpoint provides a redirection to the Strava login page.
+/// Handles the user login process by redirecting to the Strava login page.
 /// </summary>
 public static class Login
 {

--- a/Doyep.Analyzer.Api/Features/Health.cs
+++ b/Doyep.Analyzer.Api/Features/Health.cs
@@ -1,0 +1,12 @@
+namespace Doyep.Analyzer.Api;
+
+/// <summary>
+/// This class contains the endpoint for checking the health of the API.
+/// </summary>
+public static class Health
+{
+    public static IResult Handle()
+    {
+        return Results.Ok("Healthy");
+    }
+}

--- a/Doyep.Analyzer.Api/Program.cs
+++ b/Doyep.Analyzer.Api/Program.cs
@@ -1,15 +1,20 @@
 using Scalar.AspNetCore;
 
-using Doyep.Analyzer.Application.Strava;
 using Doyep.Analyzer.Infrastructure;
+using Doyep.Analyzer.Api;
+using Doyep.Analyzer.Infrastructure.Strava;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services
+    .AddOptions<StravaApplicationOptions>()
+    .BindConfiguration(StravaApplicationOptions.SectionName)
+    .ValidateOnStart();
+builder.Services
     .AddOpenApi()
-    .AddStrava(builder.Configuration);
+    .AddStrava();
 
 var app = builder.Build();
 
@@ -21,11 +26,9 @@ if (app.Environment.IsDevelopment())
     app.MapGet("/", () => Results.Redirect("/scalar")).ExcludeFromDescription();
 }
 
-app.UseHttpsRedirection();
+app.MapApiEndpoints();
+app.MapAuthEndpoints();
 
-app.MapGet("/strava/token/{code}", async (string code, IStravaAuthenticationService strava) =>
-{
-    return await strava.ExchangeToken(code);
-});
+app.UseHttpsRedirection();
 
 app.Run();

--- a/Doyep.Analyzer.Api/Program.cs
+++ b/Doyep.Analyzer.Api/Program.cs
@@ -1,3 +1,5 @@
+using Scalar.AspNetCore;
+
 using Doyep.Analyzer.Application.Strava;
 using Doyep.Analyzer.Infrastructure;
 
@@ -15,6 +17,8 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
+    app.MapScalarApiReference();
+    app.MapGet("/", () => Results.Redirect("/scalar")).ExcludeFromDescription();
 }
 
 app.UseHttpsRedirection();

--- a/Doyep.Analyzer.Api/Properties/launchSettings.json
+++ b/Doyep.Analyzer.Api/Properties/launchSettings.json
@@ -5,16 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5176",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7009;http://localhost:5176",
+      "applicationUrl": "http://0.0.0.0:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Doyep.Analyzer.Api/appsettings.json
+++ b/Doyep.Analyzer.Api/appsettings.json
@@ -1,14 +1,14 @@
 {
+  "AllowedHosts": "<ALLOWED_HOSTS>",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "Strava": {
-    "BaseUrl": "https://www.strava.com/api/v3",
-    "ClientId": "YOUR_CLIENT_ID",
-    "ClientSecret": "YOUR_CLIENT_SECRET"
+  "StravaApplication": {
+    "ClientId": "<YOUR_CLIENT_ID>",
+    "ClientSecret": "<YOUR_CLIENT_SECRET>",
+    "RedirectUri": "<YOUR_REGISTERED_REDIRECT_URI>"
   }
 }

--- a/Doyep.Analyzer.Application/Auth/ScopeValidator.cs
+++ b/Doyep.Analyzer.Application/Auth/ScopeValidator.cs
@@ -1,0 +1,30 @@
+namespace Doyep.Analyzer.Application.Auth;
+
+/// <summary>
+/// Utility class to validate if the scopes granted by the user include all the required scopes for the application to works properly.
+/// </summary>
+public static class ScopeValidator
+{
+
+    /// <summary>
+    /// The list of scopes required by the application to works properly.
+    /// These scopes are required to be included in the authorization URL and to be granted by the user during the OAuth flow.
+    /// </summary>
+    public static readonly string[] RequiredScopes = [
+        "read",
+        "read_all",
+        "profile:read_all",
+        "activity:read_all"
+    ];
+
+    /// <summary>
+    /// Checks if the scopes granted by the user include all the required scope for the application to works properly.
+    /// </summary>
+    /// <param name="scopesRaw">The list of scopes granted by the user</param>
+    /// <returns>True if all the required scopes are included in the granted scopes, false otherwise.</returns>
+    public static bool HasRequiredScope(string scopesRaw)
+    {
+        var scopes = scopesRaw.Split(',');
+        return RequiredScopes.All(scopes.Contains);
+    }
+}

--- a/Doyep.Analyzer.Application/Strava/Interfaces/IStravaAuthenticationService.cs
+++ b/Doyep.Analyzer.Application/Strava/Interfaces/IStravaAuthenticationService.cs
@@ -1,6 +1,33 @@
 namespace Doyep.Analyzer.Application.Strava;
 
+/// <summary>
+/// Provides authentication and token management throught the Strava Api
+/// </summary>
 public interface IStravaAuthenticationService
 {
-    Task<string> ExchangeToken(string authorizationCode);
+    /// <summary>
+    /// Redirects the user to the Strava OAuth authorization URL to initiate the login workflow.
+    /// </summary>
+    /// <returns>The formatted URL string for the Strava login page.</returns>
+    string GenerateLoginUrl();
+
+    /// <summary>
+    /// Exchange an authorization code with a full token response and summary authenticated Athlete.
+    /// </summary>
+    /// <param name="authorizationCode">The code recieved from the Strava OAuth callback.</param>
+    /// <returns>A task representing the token response and the summary authenticated Athlete or null if exchange fails.</returns>
+    Task<StravaTokenResponse?> ExchangeToken(string authorizationCode);
+    /// <summary>
+    /// Refreshes an expired access token with a refresh token.
+    /// </summary>
+    /// <param name="refreshToken">A valid refresh token.</param>
+    /// <returns>A task representing the new token response or null if renewall fails.</returns>
+    Task<StravaTokenResponse?> RefreshToken(string refreshToken);
+
+    /// <summary>
+    /// Revoke the current access token from the application.
+    /// </summary>
+    /// <param name="accessToken">An active access token to be invalidated.</param>
+    /// <returns>A task representing the asynchronous deauthorization process.</returns>
+    Task Deauthorize(string accessToken);
 }

--- a/Doyep.Analyzer.Application/Strava/StravaTokenResponse.cs
+++ b/Doyep.Analyzer.Application/Strava/StravaTokenResponse.cs
@@ -1,0 +1,13 @@
+namespace Doyep.Analyzer.Application.Strava;
+
+/// <summary>
+/// Represents the response returned by the Strava token exchange endpoint.
+/// </summary>
+public record StravaTokenResponse(
+    string TokenType,
+    TimeSpan ExpiresIn,
+    DateTimeOffset ExpiresAt,
+    string RefreshToken,
+    string AccessToken,
+    Athlete? Athlete
+);

--- a/Doyep.Analyzer.Application/Strava/SummaryAthlete.cs
+++ b/Doyep.Analyzer.Application/Strava/SummaryAthlete.cs
@@ -1,0 +1,21 @@
+namespace Doyep.Analyzer.Application.Strava;
+
+/// <summary>
+/// Represents Athlete informations
+/// </summary>
+public record Athlete(
+    long Id,
+    int ResourceState,
+    string Firstname,
+    string Lastname,
+    string? ProfileMedium,
+    string? Profile,
+    string? City,
+    string? State,
+    string? Country,
+    string Sex,
+    bool Premium,
+    bool Summit,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);

--- a/Doyep.Analyzer.Infrastructure/DependencyInjection/StravaServiceCollectionExtensions.cs
+++ b/Doyep.Analyzer.Infrastructure/DependencyInjection/StravaServiceCollectionExtensions.cs
@@ -1,26 +1,26 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
-using Doyep.Analyzer.Infrastructure.Strava;
 using Doyep.Analyzer.Application.Strava;
+using Doyep.Analyzer.Infrastructure.Strava;
 
 namespace Doyep.Analyzer.Infrastructure;
 
+/// <summary>
+/// Provide extension methods for registering Strava integration services.
+/// This includes configuration options and the Strava authentication service.
+/// </summary>
 public static class StravaServiceCollectionExtensions
 {
-    public static IServiceCollection AddStrava(
-        this IServiceCollection services,
-        IConfiguration configuration)
-    {
-        services.Configure<StravaOptions>(configuration.GetSection("Strava"));
 
-        services.AddHttpClient<IStravaAuthenticationService, StravaAuthenticationService>()
-            .ConfigureHttpClient((serviceProvider, client) =>
-            {
-                var options = serviceProvider.GetRequiredService<IOptions<StravaOptions>>().Value;
-                client.BaseAddress = new Uri(options.BaseUrl);
-            });
+    /// <summary>
+    /// Register Strava integration services, such as the Strava authentication service.
+    /// </summary>
+    public static IServiceCollection AddStrava(this IServiceCollection services)
+    {
+        services.AddHttpClient<IStravaAuthenticationService, StravaAuthenticationService>((client) =>
+        {
+            client.BaseAddress = new Uri(StravaEndpoints.BaseUrl);
+        });
 
         return services;
     }

--- a/Doyep.Analyzer.Infrastructure/Doyep.Analyzer.Infrastructure.csproj
+++ b/Doyep.Analyzer.Infrastructure/Doyep.Analyzer.Infrastructure.csproj
@@ -7,10 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaApprovalPrompts.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaApprovalPrompts.cs
@@ -1,0 +1,10 @@
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Approval prompts used in the Strava Oauth 2.0 workflow.
+/// </summary>
+public static class StravaApprovalPrompts
+{
+    public const string Force = "force";
+    public const string Auto = "auto";
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaEndpoints.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaEndpoints.cs
@@ -1,0 +1,27 @@
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Static class containing constants related to the Strava API integration, such as base URLs and endpoint paths.
+/// </summary>
+public static class StravaEndpoints
+{
+    /// <summary>
+    /// Base URL of the Strava
+    /// </summary>
+    public const string BaseUrl = "https://www.strava.com";
+
+    /// <summary>
+    /// Endpoint for initiating the OAuth 2.0 authorization flow with Strava.
+    /// </summary>
+    public const string AuthorizeEndpoint = "oauth/authorize";
+
+    /// <summary>
+    /// Endpoint for exchanging an authorization code for an access token with Strava.
+    /// </summary>
+    public const string TokenEndpoint = "oauth/token";
+
+    /// <summary>
+    /// Endpoint for deauthorizing the application from a user's Strava account.
+    /// </summary>
+    public const string DeauthorizeEndpoint = "oauth/deauthorize";
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaGrantTypes.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaGrantTypes.cs
@@ -1,0 +1,10 @@
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Grant types used in the Strava Oauth 2.0 workflow.
+/// </summary>
+public static class StravaGrantTypes
+{
+    public const string AuthorizationCode = "authorization_code";
+    public const string RefreshToken = "refresh_token";
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaResponseTypes.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Constants/StravaResponseTypes.cs
@@ -1,0 +1,9 @@
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Response types used in the Strava Oauth 2.0 workflow.
+/// </summary>
+public static class StravaResponseTypes
+{
+    public const string Code = "code";
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Dto/StravaTokenResponseDto.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Dto/StravaTokenResponseDto.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Represents the response returned by the Strava token exchange endpoint.
+/// </summary>
+public record StravaTokenResponseDto
+{
+    /// <summary>
+    /// Always <c>Bearer</c>
+    /// </summary>
+    [property: JsonPropertyName("token_type")]
+    public required string TokenType { get; init; }
+
+    /// <summary>
+    /// Seconds until the short-lived access token will expire
+    /// </summary>
+    [property: JsonPropertyName("expires_in")]
+    public required int ExpiresIn { get; init; }
+
+    /// <summary>
+    /// The number of seconds since the epoch when the provided access token will expire
+    /// </summary>
+    [property: JsonPropertyName("expires_at")]
+    public required long ExpiresAt { get; init; }
+
+    /// <summary>
+    /// The refresh token for this user, to be used to get the next access token for this user. Please expect that this value can change anytime you retrieve a new access token. Once a new refresh token code has been returned, the older code will no longer work.
+    /// </summary>
+    [property: JsonPropertyName("refresh_token")]
+    public required string RefreshToken { get; init; }
+
+    /// <summary>
+    /// The access token, to be used to fetch personnal data for this user.
+    /// </summary>
+    [property: JsonPropertyName("access_token")]
+    public required string AccessToken { get; init; }
+
+    /// <summary>
+    /// The auth <see cref="SummaryAthleteDto"/>.
+    /// </summary>
+    [property: JsonPropertyName("athlete")]
+    public required SummaryAthleteDto? Athlete { get; init; }
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Dto/SummaryAthleteDto.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Dto/SummaryAthleteDto.cs
@@ -1,0 +1,93 @@
+using System.Text.Json.Serialization;
+
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Represents a summary of Strava Athlete informations.
+/// </summary>
+public record SummaryAthleteDto
+{
+    /// <summary>
+    /// The unique identifier of the athlete
+    /// </summary>
+    [property: JsonPropertyName("id")]
+    public required long Id { get; init; }
+
+    /// <summary>
+    /// Resource state, indicates level of detail. Possible values: 1 -> "meta", 2 -> "summary", 3 -> "detail"
+    /// </summary>
+    [property: JsonPropertyName("resource_state")]
+    public required int ResourceState { get; init; }
+
+    /// <summary>
+    /// The athlete's first name.
+    /// </summary>
+    [property: JsonPropertyName("firstname")]
+    public required string Firstname { get; init; }
+
+    /// <summary>
+    /// The athlete's last name.
+    /// </summary>
+    [property: JsonPropertyName("lastname")]
+    public required string Lastname { get; init; }
+
+    /// <summary>
+    /// URL to a 62x62 pixel profile picture.
+    /// </summary>
+    [property: JsonPropertyName("profile_medium")]
+    public required string? ProfileMedium { get; init; }
+
+    /// <summary>
+    /// URL to a 124x124 pixel profile picture.
+    /// </summary>
+    [property: JsonPropertyName("profile")]
+    public required string? Profile { get; init; }
+
+    /// <summary>
+    /// The athlete's city.
+    /// </summary>
+    [property: JsonPropertyName("city")]
+    public required string? City { get; init; }
+
+    /// <summary>
+    /// The athlete's state or geographical region.
+    /// </summary>
+    [property: JsonPropertyName("state")]
+    public required string? State { get; init; }
+
+    /// <summary>
+    /// The athlete's country.
+    /// </summary>
+    [property: JsonPropertyName("country")]
+    public required string? Country { get; init; }
+
+    /// <summary>
+    /// The athlete's sex. May take one of the following values: M, F
+    /// </summary>
+    [property: JsonPropertyName("sex")]
+    public required string Sex { get; init; }
+
+    /// <summary>
+    /// Deprecated. Use summit field instead. Whether the athlete has any Summit subscription.
+    /// </summary>
+    [property: JsonPropertyName("premium")]
+    public required bool Premium { get; init; }
+
+    /// <summary>
+    /// Whether the athlete has any Summit subscription.
+    /// </summary>
+    [property: JsonPropertyName("summit")]
+    public required bool Summit { get; init; }
+
+    /// <summary>
+    /// The time at which the athlete was created.
+    /// </summary>
+    [property: JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; init; }
+
+    /// <summary>
+    /// The time at which the athlete was last updated.
+    /// </summary>
+    [property: JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; init; }
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/Mappers/StravaDtoMapper.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/Mappers/StravaDtoMapper.cs
@@ -1,0 +1,42 @@
+using Doyep.Analyzer.Application.Strava;
+
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Provides extensions methods to map Strava DTOs to application models
+/// </summary>
+public static class StravaDtoMapper
+{
+
+    /// <summary>
+    /// Maps a <see cref="StravaTokenResponseDto"/> to a <see cref="StravaTokenResponse"/>
+    /// </summary>
+    public static StravaTokenResponse ToModel(this StravaTokenResponseDto dto) => new(
+        dto.TokenType,
+        TimeSpan.FromSeconds(dto.ExpiresIn),
+        DateTimeOffset.FromUnixTimeSeconds(dto.ExpiresAt).UtcDateTime,
+        dto.RefreshToken,
+        dto.AccessToken,
+        dto.Athlete?.ToModel()
+    );
+
+    /// <summary>
+    /// Maps a <see cref="SummaryAthleteDto"/> to a <see cref="Athlete"/>
+    /// </summary>
+    public static Athlete ToModel(this SummaryAthleteDto dto) => new(
+        dto.Id,
+        dto.ResourceState,
+        dto.Firstname,
+        dto.Lastname,
+        dto.ProfileMedium,
+        dto.Profile,
+        dto.City,
+        dto.State,
+        dto.Country,
+        dto.Sex,
+        dto.Premium,
+        dto.Summit,
+        new DateTimeOffset(dto.CreatedAt),
+        new DateTimeOffset(dto.UpdatedAt)
+    );
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/StravaApplicationOptions.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/StravaApplicationOptions.cs
@@ -1,0 +1,30 @@
+namespace Doyep.Analyzer.Infrastructure.Strava;
+
+/// <summary>
+/// Configuration options for the Strava API integration.
+/// These values are loaded from the "Strava" section of appsettings.json, from
+/// environment variables or user secrets.
+/// </summary>
+public class StravaApplicationOptions
+{
+    /// <summary>
+    /// Section name of appsettings.json
+    /// </summary>
+    public const string SectionName = "StravaApplication";
+
+    /// <summary>
+    /// OAuth 2.0 client identifier provided by Strava for the application
+    /// </summary>
+    public required string ClientId { get; set; }
+
+    /// <summary>
+    /// OAuth 2.0 client secret associated with the application.
+    /// This value should be stored securely.
+    /// </summary>
+    public required string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Redirect URI registered with Strava for the application. This is the URL to which Strava will redirect users after they authorize the application.
+    /// </summary>
+    public required string RedirectUri { get; set; }
+}

--- a/Doyep.Analyzer.Infrastructure/Strava/StravaAuthenticationService.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/StravaAuthenticationService.cs
@@ -1,33 +1,92 @@
-using Doyep.Analyzer.Application.Strava;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+
+using Doyep.Analyzer.Application.Auth;
+using Doyep.Analyzer.Application.Strava;
 
 namespace Doyep.Analyzer.Infrastructure.Strava;
 
+/// <summary>
+/// Handles Strava OAuth 2.0 authentication workflows using <see cref="HttpClient"/>.
+/// </summary>
 public class StravaAuthenticationService : IStravaAuthenticationService
 {
     private readonly HttpClient _httpClient;
-    private readonly StravaOptions _options;
+    private readonly StravaApplicationOptions _options;
 
-    public StravaAuthenticationService(HttpClient httpClient, IOptions<StravaOptions> options)
+    public StravaAuthenticationService(HttpClient httpClient, IOptions<StravaApplicationOptions> options)
     {
         _httpClient = httpClient;
         _options = options.Value;
     }
 
-    public async Task<string> ExchangeToken(string authorizationCode)
+    /// <inheritdoc/>
+    public string GenerateLoginUrl()
     {
-        var values = new Dictionary<string, string>
+        var queries = new Dictionary<string, string?>
+        {
+            { "client_id", _options.ClientId },
+            { "redirect_uri", _options.RedirectUri },
+            { "response_type", StravaResponseTypes.Code },
+            { "approval_prompt", StravaApprovalPrompts.Force },
+            { "scope", string.Join(",", ScopeValidator.RequiredScopes) },
+        };
+
+        var baseUrl = new Uri(StravaEndpoints.BaseUrl);
+        var authorizeUrl = new Uri(baseUrl, StravaEndpoints.AuthorizeEndpoint);
+
+        return QueryHelpers.AddQueryString(authorizeUrl.ToString(), queries);
+    }
+
+    /// <inheritdoc/>
+    public async Task<StravaTokenResponse?> ExchangeToken(string authorizationCode)
+    {
+        var body = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             { "client_id", _options.ClientId },
             { "client_secret", _options.ClientSecret },
-            { "code", authorizationCode },
-            { "grant_type", "authorization_code" }
-        };
-        var content = new FormUrlEncodedContent(values);
+            { "grant_type", StravaGrantTypes.AuthorizationCode },
+            { "code", authorizationCode }
+        });
 
-        var response = await _httpClient.PostAsync("/oauth/token", content);
+        var response = await _httpClient.PostAsync(StravaEndpoints.TokenEndpoint, body);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStringAsync();
+        var dto = await response.Content.ReadFromJsonAsync<StravaTokenResponseDto>();
+        return dto!.ToModel();
+    }
+
+    /// <inheritdoc/>
+    public async Task<StravaTokenResponse?> RefreshToken(string refreshToken)
+    {
+        var body = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "client_id", _options.ClientId },
+            { "client_secret", _options.ClientSecret },
+            { "grant_type", StravaGrantTypes.RefreshToken },
+            { "refresh_token ", refreshToken }
+        });
+
+        var response = await _httpClient.PostAsync(StravaEndpoints.TokenEndpoint, body);
+        response.EnsureSuccessStatusCode();
+
+        var dto = await response.Content.ReadFromJsonAsync<StravaTokenResponseDto>();
+        return dto!.ToModel();
+    }
+
+    /// <inheritdoc/>
+    public async Task Deauthorize(string accessToken)
+    {
+        var queries = new Dictionary<string, string?>
+        {
+            { "access_token", accessToken }
+        };
+
+        var url = QueryHelpers.AddQueryString("oauth/deauthorize", queries);
+
+        var response = await _httpClient.PostAsync(url, null);
+
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/Doyep.Analyzer.Infrastructure/Strava/StravaOptions.cs
+++ b/Doyep.Analyzer.Infrastructure/Strava/StravaOptions.cs
@@ -1,9 +1,0 @@
-namespace Doyep.Analyzer.Infrastructure.Strava;
-
-public class StravaOptions
-{
-    public required string BaseUrl { get; set; }
-    public required string ClientId { get; set; }
-    public required string ClientSecret { get; set; }
-
-}

--- a/README.md
+++ b/README.md
@@ -2,14 +2,22 @@
 
 Web Application for analyzing performance for athletes and their friends based on Strava API.
 
-At this moment, this repository only contains WebApi. The Ui will be add someday.
+At this moment, this repository only contains WebApi. The Ui will be added someday.
 
 # Requirements
 
-This API need the `ClientId` and `ClientSecret`.
-You can use ENVIRONMENT VARIABLES or User Secrets
+This API need the following informations :
+- `AllowedHosts`
+- `ClientId` 
+- `ClientSecret`
+- `RedirectUri`
+
+You can use ENVIRONMENT VARIABLES or User Secrets (Doyep.Anlyzer.Api layer)
+
 ```bash
 dotnet user-secrets init
-dotnet user-secrets set "Strava:ClientId" "..."
-dotnet user-secrets set "Strava:ClientSecret" "..."
+dotnet user-secrets set "AllowedHosts" "..."
+dotnet user-secrets set "StravaApplication:ClientId" "..."
+dotnet user-secrets set "StravaApplication:ClientSecret" "..."
+dotnet user-secrets set "StravaApplication:RedirectUri" "..."
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# analyzer
+# Analyzer
 
 Web Application for analyzing performance for athletes and their friends based on Strava API.
+
+At this moment, this repository only contains WebApi. The Ui will be add someday.
 
 # Requirements
 


### PR DESCRIPTION
# Contenu de cette PR : 

## Features : 
- Ajoute `Scalar` au projet
- Créer l'endpoint `api/health`
- Créer l'endpoint `auth/login`
  Avant j'avais un service qui génèrait l'url de la page de login Strava pour la renvoyer au front pour qu'il mette le lien dans un `<a href="..."></a>`.
  J'ai trouvé ma première utilisation du StatusCode 302. Maintenant, une fois que j'appelle la `route/login`, je redirige automatiquement vers le liens que j'aurai généré. 🔥 
- Modifie l'endpoint `/strava/token/{code}` en `/auth/callback`
  Avant je récupérais l'`authorizationCode` via le front car le `redirect_uri` était un lien front et c'est lui qui faisait l'`exchangeToken`.
  Dans la version intermédiaire ([PR](https://github.com/doyep/analyzer/pull/2) qui a été cloturée), je comptais récupérer l'`authorizationCode` via le front toujours mais envoyer ce code au back pour qu'il puisse faire l'`exchangeToken` (pour ne plus exposer ClientSecret).
  💡 J'ai trouvé encore mieux en mettant en `redirect_uri` directement `/auth/callback`. Ainsi, c'est le back qui récupère le code et les scopes cochés par l'utilisateur. Il vérifie maintenant que l'utilisateur a bien tout coché pour le bon fonctionnement futur de l'application (j'étais bloqué avant, même si je pouvais faire le control de scope côté front, il était possible pour une personne mal intentionnée de tricher).
  Cet endpoint est toujours en work in progress car je vais maintenant ajouter une gestion de WhiteList pour autoriser les utilisateurs que j'aurai en base de donnée. Mais je m'arrête là pour cette PR qui est déjà assez conséquente !!
- Adopte une architecture feature slice propre dans Api/Features
 
## Chores : 
- Ajout de documentation dans tous les sens (@pBouillon 😓🤬😵‍💫)
- Mets à jour le README
- Un peu de ménage dans les fichiers 

--- 
Bonne relecture 😎